### PR TITLE
Implement ingestion and database setup

### DIFF
--- a/DIFF_20250618T234736Z.md
+++ b/DIFF_20250618T234736Z.md
@@ -1,0 +1,18 @@
+# DIFF 2025-06-18T23:47:36Z
+
+
+- Initial diff log created.
+
+
+## Changes Added
+
+ M README.md
+?? DIFF_20250618T234736Z.md
+?? RECOMMENDATIONS_20250618T234736Z.md
+?? packages/ingestion/
+?? scripts/databases/
+?? scripts/ingest_web.py
+?? terraform/
+- Added ingestion package, database scripts, Terraform configs, and ingestion script.
+- Updated README with database recommendation.
+

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ An intelligent document assembly system that combines targeted web crawling, AI-
    - Document preview and editing
    - Configuration management
 
+## Database Recommendation
+
+DocAssembler stores raw text in a traditional relational database and vectors in a vector database. By default we recommend **MySQL** for document metadata and **ChromaDB** for vector search. Example setup scripts are located in `scripts/databases/`.
+
 ## Getting Started
 
 ### Prerequisites

--- a/RECOMMENDATIONS_20250618T234736Z.md
+++ b/RECOMMENDATIONS_20250618T234736Z.md
@@ -1,0 +1,6 @@
+# RECOMMENDATIONS 2025-06-18T23:47:36Z
+
+
+- Use ChromaDB for vector storage and MySQL for metadata.
+- Consider fixing pre-commit flake8 issues and dependency installation.
+

--- a/packages/ingestion/README.md
+++ b/packages/ingestion/README.md
@@ -1,0 +1,3 @@
+# Ingestion Package
+
+Provides utilities for ingesting text from the web, chunking it into manageable pieces, and streaming those chunks for database storage. This package is intended to standardize ingestion across different websites.

--- a/packages/ingestion/pyproject.toml
+++ b/packages/ingestion/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.poetry]
+name = "ingestion"
+version = "0.1.0"
+description = "Utilities for text ingestion, chunking, and streaming"
+authors = ["CloudCurio <dev@cloudcurio.cc>"]
+packages = [{include = "ingestion", from = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.12"
+aiohttp = "^3.9"
+beautifulsoup4 = "^4.13.4"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.5"
+black = "^25.1.0"
+mypy = "^1.15.0"
+
+[build-system]
+requires = ["poetry-core>=2.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+line-length = 100
+target-version = ["py312"]
+
+[tool.mypy]
+python_version = "3.12"
+disallow_untyped_defs = true
+check_untyped_defs = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]

--- a/packages/ingestion/src/ingestion/__init__.py
+++ b/packages/ingestion/src/ingestion/__init__.py
@@ -1,0 +1,6 @@
+"""Ingestion package initialization."""
+
+from .chunker import chunk_text
+from .streamer import stream_chunks
+
+__all__ = ["chunk_text", "stream_chunks"]

--- a/packages/ingestion/src/ingestion/chunker.py
+++ b/packages/ingestion/src/ingestion/chunker.py
@@ -1,0 +1,22 @@
+"""Text chunking utilities."""
+
+from typing import List
+
+
+def chunk_text(text: str, max_chars: int = 1000) -> List[str]:
+    """Split text into chunks of approximately max_chars characters."""
+    words = text.split()
+    chunks: list[str] = []
+    current: list[str] = []
+    length = 0
+    for word in words:
+        if length + len(word) + 1 > max_chars:
+            chunks.append(" ".join(current))
+            current = [word]
+            length = len(word) + 1
+        else:
+            current.append(word)
+            length += len(word) + 1
+    if current:
+        chunks.append(" ".join(current))
+    return chunks

--- a/packages/ingestion/src/ingestion/streamer.py
+++ b/packages/ingestion/src/ingestion/streamer.py
@@ -1,0 +1,14 @@
+"""Streaming utilities for ingestion."""
+
+import asyncio
+from typing import AsyncGenerator, Iterable
+
+
+async def stream_chunks(
+    chunks: Iterable[str], delay: float = 0.0
+) -> AsyncGenerator[str, None]:
+    """Asynchronously yield chunks."""
+    for chunk in chunks:
+        yield chunk
+        if delay:
+            await asyncio.sleep(delay)

--- a/packages/ingestion/tests/test_chunker.py
+++ b/packages/ingestion/tests/test_chunker.py
@@ -1,0 +1,11 @@
+"""Tests for chunker."""
+
+from ingestion.chunker import chunk_text
+
+
+def test_chunk_text_basic():
+    """Verify chunk_text splits text."""
+    text = "one two three four five six seven"
+    chunks = chunk_text(text, max_chars=10)
+    assert len(chunks) > 1
+    assert "one" in chunks[0]

--- a/scripts/databases/chroma_setup.py
+++ b/scripts/databases/chroma_setup.py
@@ -1,0 +1,19 @@
+"""Simple helper to store documents in ChromaDB."""
+
+from typing import Sequence
+
+import chromadb
+
+
+def store_documents(docs: Sequence[str], collection_name: str = "docs") -> None:
+    """Store documents in ChromaDB collection."""
+    client = chromadb.Client()
+    collection = client.get_or_create_collection(collection_name)
+    for i, doc in enumerate(docs):
+        collection.add(documents=[doc], ids=[str(i)])
+
+
+if __name__ == "__main__":
+    example_docs = ["hello world", "another document"]
+    store_documents(example_docs)
+    print("Stored example documents in ChromaDB.")

--- a/scripts/databases/clickhouse_setup.sql
+++ b/scripts/databases/clickhouse_setup.sql
@@ -1,0 +1,6 @@
+-- ClickHouse table for storing document chunks
+CREATE TABLE IF NOT EXISTS documents (
+    id UInt64,
+    content String,
+    created DateTime DEFAULT now()
+) ENGINE = MergeTree() ORDER BY id;

--- a/scripts/databases/faiss_setup.py
+++ b/scripts/databases/faiss_setup.py
@@ -1,0 +1,17 @@
+"""Create FAISS index and store example documents."""
+
+import faiss
+import numpy as np
+
+
+def create_index(embeddings: np.ndarray) -> faiss.IndexFlatL2:
+    """Create an in-memory FAISS index."""
+    index = faiss.IndexFlatL2(embeddings.shape[1])
+    index.add(embeddings)
+    return index
+
+
+if __name__ == "__main__":
+    sample_embeddings = np.random.rand(10, 128).astype("float32")
+    index = create_index(sample_embeddings)
+    print(f"FAISS index contains {index.ntotal} vectors")

--- a/scripts/databases/mysql_setup.sql
+++ b/scripts/databases/mysql_setup.sql
@@ -1,0 +1,6 @@
+-- Simple MySQL setup for storing documents
+CREATE TABLE IF NOT EXISTS documents (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    content TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/scripts/ingest_web.py
+++ b/scripts/ingest_web.py
@@ -1,0 +1,30 @@
+"""Simple web ingestion script using the ingestion package."""
+
+import asyncio
+
+from aiohttp import ClientSession
+from bs4 import BeautifulSoup
+from ingestion import chunk_text, stream_chunks
+
+
+async def fetch_text(url: str) -> str:
+    """Fetch plain text from the given URL."""
+    async with ClientSession() as session:
+        async with session.get(url) as response:
+            html = await response.text()
+            soup = BeautifulSoup(html, "html.parser")
+            return soup.get_text(separator=" ")
+
+
+async def main(url: str) -> None:
+    """Ingest the page and print chunk previews."""
+    text = await fetch_text(url)
+    chunks = chunk_text(text)
+    async for chunk in stream_chunks(chunks):
+        print(chunk[:80])
+
+
+if __name__ == "__main__":
+    import sys
+
+    asyncio.run(main(sys.argv[1]))

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "docs" {
+  bucket = var.bucket_name
+  acl    = "private"
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+variable "bucket_name" {
+  default = "doc-assembler-storage"
+}

--- a/terraform/oracle/main.tf
+++ b/terraform/oracle/main.tf
@@ -1,0 +1,25 @@
+provider "oci" {
+  region = var.region
+}
+
+resource "oci_objectstorage_bucket" "docs" {
+  namespace = var.namespace
+  name      = var.bucket_name
+  compartment_id = var.compartment_id
+}
+
+variable "region" {
+  default = "us-ashburn-1"
+}
+
+variable "namespace" {
+  description = "Object storage namespace"
+}
+
+variable "bucket_name" {
+  default = "doc-assembler-storage"
+}
+
+variable "compartment_id" {
+  description = "OCID of the compartment"
+}


### PR DESCRIPTION
## Summary
- add new ingestion package for text chunking and streaming
- update README with database recommendation
- create scripts for Chroma and FAISS setup
- provide example MySQL and ClickHouse SQL
- add Terraform configs for AWS and Oracle free tiers
- add ingestion example script

## Testing
- `pre-commit run --files packages/ingestion/src/ingestion/__init__.py packages/ingestion/src/ingestion/chunker.py packages/ingestion/src/ingestion/streamer.py packages/ingestion/tests/test_chunker.py scripts/databases/chroma_setup.py scripts/databases/faiss_setup.py scripts/ingest_web.py README.md DIFF_20250618T234736Z.md RECOMMENDATIONS_20250618T234736Z.md packages/ingestion/README.md packages/ingestion/pyproject.toml scripts/databases/clickhouse_setup.sql scripts/databases/mysql_setup.sql terraform/aws/main.tf terraform/oracle/main.tf` *(fails: Could not complete due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68534fcc6d64832ab236ea7118566678